### PR TITLE
Run CI only on pull requests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,8 +1,6 @@
 name: .NET CI
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- update GitHub Actions CI trigger to `pull_request` only

## Testing
- `dotnet test AdventOfCode.sln --no-build --verbosity normal -maxcpucount:1` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840227c92bc8323bdc85dfb39e93260