### PR TITLE
Remove max CPU limit from tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Build
         run: dotnet build AdventOfCode.sln --configuration Release --no-restore
       - name: Test
-        run: dotnet test AdventOfCode.sln --configuration Release --verbosity normal -maxcpucount:1
+        run: dotnet test AdventOfCode.sln --configuration Release --verbosity normal


### PR DESCRIPTION
## Summary
- remove the `-maxcpucount:1` flag from the dotnet test step so the CI can use all available cores

## Testing
- `dotnet restore AdventOfCode.sln`
- `dotnet build AdventOfCode.sln --configuration Release`
- `dotnet test AdventOfCode.sln --configuration Release --verbosity normal` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_68403e29b7b883238477e984302ae329